### PR TITLE
Small documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ You will need Microsoft Visual Studio 2013 to compile freelan. All projects come
 
 The root directory also contains a solution file (`.sln`) that references all the sub-projects.
 
+### Debugging
+
+If the debug-level logging exposed with the `-d` parameter to freelan does not expose enough information to assist development or bug finding, it is possible to enable additional debug information at build time with:
+
+> scons all --mode=debug
+
+Be aware that this will produce a significant amount of logging information and is not intended for general use.
+
+
 Graphical User Interface
 ------------------------
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ It contains the following projects:
 Building
 --------
 
-### Third-party (Windows Only)
+### Third-party
 
-The build relies on several third-parties. To build those, install the Python command `teapot` using the following command:
+The build relies on several third-parties. Generally Linux users won't need these, but other platforms such as MacOS or Windows may need these.
+
+To build those, install the Python command `teapot` using the following command:
 
 > pip install teapot
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It contains the following projects:
 Building
 --------
 
-### Third-party
+### Third-party (Windows Only)
 
 The build relies on several third-parties. To build those, install the Python command `teapot` using the following command:
 


### PR DESCRIPTION
Two documentation changes:

1. Make it clearer that third party build steps are only required for Windows builds.
2. Added instructions on how to build with debugging enabled, scons isn't particularly user friendly so having some notes to point developers or users trying to get more debug information would be useful.

Happy to amend pull request if you would prefer different location/style/wording/etc.