### PR TITLE
Optional IPv4

### DIFF
--- a/apps/freelan/config/freelan.cfg
+++ b/apps/freelan/config/freelan.cfg
@@ -418,7 +418,7 @@ public_endpoint=0.0.0.0
 #
 # Commenting out, will result in no IPv4 networking. You cannot supply a blank value.
 #
-#ipv4_address_prefix_length=9.0.0.1/24
+ipv4_address_prefix_length=9.0.0.1/24
 
 # The tap adapter IPv6 address and prefix length to use.
 #
@@ -426,7 +426,7 @@ public_endpoint=0.0.0.0
 #
 # Commenting out, will result in no IPv6 networking. You cannot supply a blank value.
 #
-#ipv6_address_prefix_length=2aa1::1/8
+ipv6_address_prefix_length=2aa1::1/8
 
 # The remote IPv4 address for tun interfaces.
 #

--- a/apps/freelan/config/freelan.cfg
+++ b/apps/freelan/config/freelan.cfg
@@ -416,18 +416,16 @@ public_endpoint=0.0.0.0
 # the netmask is determined according to the IPv4 class. It is recommended that
 # you set the network.enable_dhcp_proxy option.
 #
-# You may specify an empty value.
+# Commenting out, will result in no IPv4 networking. You cannot supply a blank value.
 #
-# Default: 9.0.0.1/24
 #ipv4_address_prefix_length=9.0.0.1/24
 
 # The tap adapter IPv6 address and prefix length to use.
 #
 # The network address must be in numeric format with a netmask suffix.
 #
-# You may specify an empty value.
+# Commenting out, will result in no IPv6 networking. You cannot supply a blank value.
 #
-# Default: 2aa1::1/8
 #ipv6_address_prefix_length=2aa1::1/8
 
 # The remote IPv4 address for tun interfaces.

--- a/apps/freelan/src/configuration_helper.cpp
+++ b/apps/freelan/src/configuration_helper.cpp
@@ -293,8 +293,8 @@ po::options_description get_tap_adapter_options()
 	("tap_adapter.name", po::value<std::string>(), "The name of the tap adapter to use or create.")
 	("tap_adapter.mtu", po::value<fl::mtu_type>()->default_value(fl::auto_mtu_type()), "The MTU of the tap adapter.")
 	("tap_adapter.metric", po::value<fl::metric_type>()->default_value(fl::auto_metric_type()), "The metric of the tap adapter.")
-	("tap_adapter.ipv4_address_prefix_length", po::value<asiotap::ipv4_network_address>()->default_value(default_ipv4_network_address), "The tap adapter IPv4 address and prefix length.")
-	("tap_adapter.ipv6_address_prefix_length", po::value<asiotap::ipv6_network_address>()->default_value(default_ipv6_network_address), "The tap adapter IPv6 address and prefix length.")
+	("tap_adapter.ipv4_address_prefix_length", po::value<asiotap::ipv4_network_address>(), "The tap adapter IPv4 address and prefix length.")
+	("tap_adapter.ipv6_address_prefix_length", po::value<asiotap::ipv6_network_address>(), "The tap adapter IPv6 address and prefix length.")
 	("tap_adapter.remote_ipv4_address", po::value<asiotap::ipv4_network_address>(), "The tap adapter IPv4 remote address.")
 	("tap_adapter.arp_proxy_enabled", po::value<bool>()->default_value(false), "Whether to enable the ARP proxy.")
 	("tap_adapter.arp_proxy_fake_ethernet_address", po::value<fl::tap_adapter_configuration::ethernet_address_type>()->default_value(boost::lexical_cast<fl::tap_adapter_configuration::ethernet_address_type>("00:aa:bb:cc:dd:ee")), "The ARP proxy fake ethernet address.")
@@ -412,8 +412,16 @@ void setup_configuration(fl::configuration& configuration, const boost::filesyst
 
 	configuration.tap_adapter.mtu = vm["tap_adapter.mtu"].as<fl::mtu_type>();
 	configuration.tap_adapter.metric = vm["tap_adapter.metric"].as<fl::metric_type>();
-	configuration.tap_adapter.ipv4_address_prefix_length = vm["tap_adapter.ipv4_address_prefix_length"].as<asiotap::ipv4_network_address>();
-	configuration.tap_adapter.ipv6_address_prefix_length = vm["tap_adapter.ipv6_address_prefix_length"].as<asiotap::ipv6_network_address>();
+
+	if (vm.count("tap_adapter.ipv4_address_prefix_length"))
+	{
+		configuration.tap_adapter.ipv4_address_prefix_length = vm["tap_adapter.ipv4_address_prefix_length"].as<asiotap::ipv4_network_address>();
+	}
+	
+	if (vm.count("tap_adapter.ipv6_address_prefix_length"))
+	{
+		configuration.tap_adapter.ipv6_address_prefix_length = vm["tap_adapter.ipv6_address_prefix_length"].as<asiotap::ipv6_network_address>();
+	}
 
 	if (vm.count("tap_adapter.remote_ipv4_address"))
 	{

--- a/libs/freelan/src/core.cpp
+++ b/libs/freelan/src/core.cpp
@@ -1530,14 +1530,7 @@ namespace freelan
 			}
 			else
 			{
-				if (m_configuration.tap_adapter.type == tap_adapter_configuration::tap_adapter_type::tun)
-				{
-				//	throw std::runtime_error("No IPv4 address configured but we are in tun mode: unable to continue");
-				}
-				else
-				{
-					m_logger(fscp::log_level::information) << "No IPv4 address configured.";
-				}
+				m_logger(fscp::log_level::information) << "No IPv4 address configured.";
 			}
 
 			// IPv6 address
@@ -1550,6 +1543,15 @@ namespace freelan
 			else
 			{
 				m_logger(fscp::log_level::information) << "No IPv6 address configured.";
+			}
+
+			// If we are running in tun mode, we need at least one
+			if (m_configuration.tap_adapter.type == tap_adapter_configuration::tap_adapter_type::tun)
+			{
+				if (m_configuration.tap_adapter.ipv4_address_prefix_length.is_null() && m_configuration.tap_adapter.ipv6_address_prefix_length.is_null())
+				{
+					throw std::runtime_error("Running in tun mode, but no IPv4 or IPv6 address provided. Unable to continue without IPv4 and/or IPv6 address being configured.");
+				}
 			}
 
 			if (m_configuration.tap_adapter.type == tap_adapter_configuration::tap_adapter_type::tun)

--- a/libs/freelan/src/core.cpp
+++ b/libs/freelan/src/core.cpp
@@ -1532,7 +1532,7 @@ namespace freelan
 			{
 				if (m_configuration.tap_adapter.type == tap_adapter_configuration::tap_adapter_type::tun)
 				{
-					throw std::runtime_error("No IPv4 address configured but we are in tun mode: unable to continue");
+				//	throw std::runtime_error("No IPv4 address configured but we are in tun mode: unable to continue");
 				}
 				else
 				{

--- a/libs/freelan/src/core.cpp
+++ b/libs/freelan/src/core.cpp
@@ -1550,7 +1550,7 @@ namespace freelan
 			{
 				if (m_configuration.tap_adapter.ipv4_address_prefix_length.is_null() && m_configuration.tap_adapter.ipv6_address_prefix_length.is_null())
 				{
-					throw std::runtime_error("Running in tun mode, but no IPv4 or IPv6 address provided. Unable to continue without IPv4 and/or IPv6 address being configured.");
+					throw std::runtime_error("Running in tun mode, but no IPv4 or IPv6 address was provided. Please configure at least one IPv4 or IPv6 address.");
 				}
 			}
 


### PR DESCRIPTION
By default freelan provides dual-stack networking, however some users like myself may wish to only tunnel IPv6 and ignore IPv4 entirely.

This isn't currently possible, since un-setting the ipv4 configuration just leads to it being reset to the default range. This pull request make both ipv4 and ipv6 networks optional so a user can have one or both. If a user fails to configure either and run in tun mode, freelan will still throw an error.

Happy to amend pull request if you want any tweaks, style changes, etc.