### PR TITLE
Makefile: use scons when compiling on a linux host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,20 @@
 #
 # To compile on Linux or Mac OSX, use `scons` (SConstruct).
 
-default: build
+UNAME := $(shell uname)
 
-build: build_x64 build_x86
-
+ifeq ($(UNAME), Linux)
+default: build_linux
+clean:
+else
+default: build_windows
 clean: clean_x64 clean_x86
+endif
+
+build_linux:
+	scons all
+
+build_windows: build_x64 build_x86
 
 build_x64:
 	msbuild freelan-all.sln /p:Configuration=Release /p:Platform=x64 /t:Build

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -2,20 +2,11 @@
 #
 # To compile on Linux or Mac OSX, use `scons` (SConstruct).
 
-UNAME := $(shell uname)
+default: build
 
-ifeq ($(UNAME), Linux)
-default: build_linux
-clean:
-else
-default: build_windows
+build: build_x64 build_x86
+
 clean: clean_x64 clean_x86
-endif
-
-build_linux:
-	scons all
-
-build_windows: build_x64 build_x86
 
 build_x64:
 	msbuild freelan-all.sln /p:Configuration=Release /p:Platform=x64 /t:Build

--- a/README.linux
+++ b/README.linux
@@ -1,0 +1,35 @@
+Building on a Linux host
+========================
+
+build-time requirements
+-----------------------
+
+Make sure you have the necessary build-time requirements installed
+
+- scons
+- python-argparse or python >= 2.7
+- libssl-dev
+- libcurl4-openssl-dev
+- libboost-system-dev
+- libboost-thread-dev,
+- libboost-program-options-dev
+- libboost-filesystem-dev,
+- libboost-iostreams-dev
+
+building from source
+--------------------
+
+check out the git master branch of freelan-all and issue the "scons all" command
+
+building for Debian, Ubuntu and derivates
+-----------------------------------------
+
+There is work going on to have proper Debian packaging available.  Please check back soon.
+
+To install the compile-time dependencies install "debhelper libssl-dev libcurl4-openssl-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-filesystem-dev libboost-iostreams-dev scons python-argparse" packages as root.
+
+
+building for other distros
+--------------------------
+
+Packaging patches and instructions will be gladly accepted

--- a/README.linux
+++ b/README.linux
@@ -26,7 +26,7 @@ building for Debian, Ubuntu and derivates
 
 There is work going on to have proper Debian packaging available.  Please check back soon.
 
-To install the compile-time dependencies install "debhelper libssl-dev libcurl4-openssl-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-filesystem-dev libboost-iostreams-dev scons python-argparse" packages as root.
+Install "debhelper libssl-dev libcurl4-openssl-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-filesystem-dev libboost-iostreams-dev scons python-argparse" packages as root to satisfy compile-time dependencies.
 
 
 building for other distros

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ It contains the following projects:
 Building
 --------
 
+See the README file specific to your host environment for general setup instructions.
+
 ### Third-party
 
 The build relies on several third-parties. Generally Linux users won't need these, but other platforms such as MacOS or Windows may need these.


### PR DESCRIPTION
A simple way to make the Makefile do the right thing on Linux as well.  Similar thing could be done for OSX but I have no way to test.