### PR TITLE
Removing duplicate config entries and typos

### DIFF
--- a/apps/freelan/config/freelan.cfg
+++ b/apps/freelan/config/freelan.cfg
@@ -47,7 +47,7 @@
 
 # The web server certificate file to use when in "https" mode.
 #
-# If no server certificate is specifed, one is generated using the hostname
+# If no server certificate is specified, one is generated using the hostname
 # guessed from the operating system which may or may not be the correct one.
 #
 # Default: <none>
@@ -402,7 +402,7 @@ public_endpoint=0.0.0.0
 # The MSS override.
 #
 # If the MSS override is enabled, FreeLAN will hijack outgoing TCP SYN frames
-# that contain a MSS value higher than the specified treshold and replace its
+# that contain a MSS value higher than the specified threshold and replace its
 # value. This has the effect of preventing IP fragmentation at the physical
 # interface level and results in tremendous performance gains for TCP connections.
 #
@@ -554,7 +554,7 @@ ipv6_address_prefix_length=2aa1::1/8
 # - switch: Act like a switch. Messages are only sent to the right host when
 # its address is known.
 # - hub: Send all messages to everyone on the network. The memory footprint is
-# slightly reduced at the cost of much higher bandwitdh usage. Recommended for
+# slightly reduced at the cost of much higher bandwidth usage. Recommended for
 # 1-to-1 networks only.
 #
 # Warning: At any time, if the memory consumption is too high, the

--- a/apps/freelan/config/freelan.cfg
+++ b/apps/freelan/config/freelan.cfg
@@ -599,7 +599,7 @@ ipv6_address_prefix_length=2aa1::1/8
 # - ipv4_proxy
 # - ipv6_proxy
 #
-# `ipv4_proxy` and `ipv4_proxy` are special values that are equivalent to
+# `ipv4_proxy` and `ipv6_proxy` are special values that are equivalent to
 # `0.0.0.0/0 => <tap_adapter.ipv4_address>` and `::/0 =>
 # <tap_adapter.ipv6_address>`.
 #
@@ -778,11 +778,6 @@ ipv6_address_prefix_length=2aa1::1/8
 #
 # Default: 2000
 #passphrase_iterations_count=2000
-
-# The salt to use when deriving the PSK from the passphrase.
-#
-# Default: freelan
-#passphrase_salt=freelan
 
 # The X509 certificate file to use for signing.
 #


### PR DESCRIPTION
Some typos and duplicate config entries in the sample freelan.cfg